### PR TITLE
Remove conda from pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ chardet==3.0.4
 Click==7.0
 cloudpickle==0.6.1
 colorama==0.3.9
-conda==4.5.11
 cryptography==2.3.1
 cycler==0.10.0
 Cython==0.29.1


### PR DESCRIPTION
The conda line in requirements.txt is unnecessary. This removes it.

Closes #11.