### PR TITLE
Target q hard initialization

### DIFF
--- a/examples/development/main.py
+++ b/examples/development/main.py
@@ -121,7 +121,7 @@ class ExperimentRunner(tune.Trainable):
         with open(pickle_path, 'wb') as f:
             pickle.dump(pickleable, f)
 
-        if self._variant['run_params'].get('save_replay_pool', False):
+        if self._variant['run_params'].get('checkpoint_replay_pool', False):
             self._save_replay_pool(checkpoint_dir)
 
         tf_checkpoint = self._get_tf_checkpoint()
@@ -175,7 +175,7 @@ class ExperimentRunner(tune.Trainable):
         replay_pool = self.replay_pool = (
             get_replay_pool_from_variant(self._variant, env))
 
-        if self._variant['run_params'].get('save_replay_pool', False):
+        if self._variant['run_params'].get('checkpoint_replay_pool', False):
             self._restore_replay_pool(checkpoint_dir)
 
         sampler = self.sampler = pickleable['sampler']
@@ -227,6 +227,10 @@ def main():
         variant_spec = get_variant_spec(universe, domain, task, args.policy)
 
     variant_spec['mode'] = args.mode
+
+    if args.checkpoint_replay_pool is not None:
+        variant_spec['run_params']['checkpoint_replay_pool'] = (
+            args.checkpoint_replay_pool)
 
     local_dir_base = (
         '~/ray_results/local'

--- a/examples/development/main.py
+++ b/examples/development/main.py
@@ -1,5 +1,6 @@
 import os
 import copy
+import glob
 from distutils.util import strtobool
 import pickle
 from pprint import pprint
@@ -83,6 +84,9 @@ class ExperimentRunner(tune.Trainable):
     def _pickle_path(self, checkpoint_dir):
         return os.path.join(checkpoint_dir, 'checkpoint.pkl')
 
+    def _replay_pool_pickle_path(self, checkpoint_dir):
+        return os.path.join(checkpoint_dir, 'replay_pool.pkl')
+
     def _tf_checkpoint_prefix(self, checkpoint_dir):
         return os.path.join(checkpoint_dir, 'checkpoint')
 
@@ -107,7 +111,6 @@ class ExperimentRunner(tune.Trainable):
         pickleable = {
             'variant': self._variant,
             'env': self.env,
-            'replay_pool': self.replay_pool,
             'sampler': self.sampler,
             'algorithm': self.algorithm,
             'Qs': self.Qs,
@@ -118,12 +121,32 @@ class ExperimentRunner(tune.Trainable):
         with open(pickle_path, 'wb') as f:
             pickle.dump(pickleable, f)
 
+        if self._variant['run_params'].get('save_replay_pool', False):
+            self._save_replay_pool(checkpoint_dir)
+
         tf_checkpoint = self._get_tf_checkpoint()
         tf_checkpoint.save(
             file_prefix=self._tf_checkpoint_prefix(checkpoint_dir),
             session=self._session)
 
         return os.path.join(checkpoint_dir, '')
+
+    def _save_replay_pool(self, checkpoint_dir):
+        replay_pool_pickle_path = self._replay_pool_pickle_path(
+            checkpoint_dir)
+        self.replay_pool.save_latest_experience(replay_pool_pickle_path)
+
+    def _restore_replay_pool(self, current_checkpoint_dir):
+        experiment_root = os.path.dirname(current_checkpoint_dir)
+
+        experience_paths = [
+            self._replay_pool_pickle_path(checkpoint_dir)
+            for checkpoint_dir in sorted(glob.iglob(
+                    os.path.join(experiment_root, 'checkpoint_*')))
+        ]
+
+        for experience_path in experience_paths:
+            self.replay_pool.load_experience(experience_path)
 
     def _restore(self, checkpoint_dir):
         assert isinstance(checkpoint_dir, str), checkpoint_dir
@@ -148,7 +171,13 @@ class ExperimentRunner(tune.Trainable):
                 sys.exit(0)
 
         env = self.env = pickleable['env']
-        replay_pool = self.replay_pool = pickleable['replay_pool']
+
+        replay_pool = self.replay_pool = (
+            get_replay_pool_from_variant(self._variant, env))
+
+        if self._variant['run_params'].get('save_replay_pool', False):
+            self._restore_replay_pool(checkpoint_dir)
+
         sampler = self.sampler = pickleable['sampler']
         Qs = self.Qs = pickleable['Qs']
         # policy = self.policy = pickleable['policy']

--- a/examples/development/variants.py
+++ b/examples/development/variants.py
@@ -157,7 +157,7 @@ ENV_PARAMS = {
     }
 }
 
-NUM_CHECKPOINTS = 5
+NUM_CHECKPOINTS = 10
 
 
 def get_variant_spec(universe, domain, task, policy):

--- a/examples/development/variants.py
+++ b/examples/development/variants.py
@@ -57,7 +57,7 @@ ALGORITHM_PARAMS_BASE = {
         'lr': 3e-4,
         'discount': 0.99,
         'target_update_interval': 1,
-        'tau': 0.005,
+        'tau': 5e-3,
         'target_entropy': 'auto',
         'reward_scale': 1.0,
         'store_extra_policy_info': False,

--- a/examples/development/variants.py
+++ b/examples/development/variants.py
@@ -62,7 +62,6 @@ ALGORITHM_PARAMS_BASE = {
         'reward_scale': 1.0,
         'store_extra_policy_info': False,
         'action_prior': 'uniform',
-        'save_full_state': False,
     }
 }
 
@@ -204,7 +203,8 @@ def get_variant_spec(universe, domain, task, policy):
                 lambda spec: np.random.randint(0, 10000)),
             'checkpoint_at_end': True,
             'checkpoint_frequency': NUM_EPOCHS_PER_DOMAIN.get(
-                domain, DEFAULT_NUM_EPOCHS) // NUM_CHECKPOINTS
+                domain, DEFAULT_NUM_EPOCHS) // NUM_CHECKPOINTS,
+            'checkpoint_replay_pool': False,
         },
     }
 

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -140,6 +140,16 @@ def get_parser(allow_policy_list=False):
                             "Whether a checkpoint should be saved at the end"
                             " of training. If set, takes precedence over"
                             " variant['run_params']['checkpoint_at_end']."))
+    parser.add_argument('--checkpoint-replay-pool',
+                        type=lambda x: bool(strtobool(x)),
+                        default=None,
+                        help=(
+                            "Whether a checkpoint should also saved the replay"
+                            " pool. If set, takes precedence over"
+                            " variant['run_params']['checkpoint_replay_pool']."
+                            " Note that the replay pool is saved (and "
+                            " constructed) piece by piece so that each"
+                            " experience is saved only once."))
     parser.add_argument('--restore',
                         type=str,
                         default=None,

--- a/softlearning/algorithms/sac.py
+++ b/softlearning/algorithms/sac.py
@@ -332,7 +332,7 @@ class SAC(RLAlgorithm):
         self._training_ops.update({'policy_train_op': policy_train_op})
 
     def _init_training(self):
-        self._update_target()
+        self._update_target(tau=1.0)
 
     def _update_target(self, tau=None):
         tau = tau or self._tau

--- a/softlearning/algorithms/sac.py
+++ b/softlearning/algorithms/sac.py
@@ -33,11 +33,11 @@ class SAC(RLAlgorithm):
             plotter=None,
             tf_summaries=False,
 
-            lr=3e-3,
+            lr=3e-4,
             reward_scale=1.0,
             target_entropy='auto',
             discount=0.99,
-            tau=0.01,
+            tau=5e-3,
             target_update_interval=1,
             action_prior='uniform',
             reparameterize=False,

--- a/softlearning/replay_pools/flexible_replay_pool.py
+++ b/softlearning/replay_pools/flexible_replay_pool.py
@@ -89,7 +89,7 @@ class FlexibleReplayPool(ReplayPool):
         return filtered_field_names
 
     def batch_by_indices(self, indices, field_name_filter=None):
-        if any(indices % self._max_size) > self.size:
+        if np.any(indices % self._max_size > self.size):
             raise ValueError(
                 "Tried to retrieve batch with indices greater than current"
                 " size")

--- a/softlearning/replay_pools/flexible_replay_pool.py
+++ b/softlearning/replay_pools/flexible_replay_pool.py
@@ -1,3 +1,6 @@
+import gzip
+import pickle
+
 import numpy as np
 
 from .replay_pool import ReplayPool
@@ -16,6 +19,7 @@ class FlexibleReplayPool(ReplayPool):
 
         self._pointer = 0
         self._size = 0
+        self._samples_since_save = 0
 
     @property
     def size(self):
@@ -34,6 +38,7 @@ class FlexibleReplayPool(ReplayPool):
     def _advance(self, count=1):
         self._pointer = (self._pointer + count) % self._max_size
         self._size = min(self._size + count, self._max_size)
+        self._samples_since_save += count
 
     def add_sample(self, **kwargs):
         self.add_samples(1, **kwargs)
@@ -103,6 +108,26 @@ class FlexibleReplayPool(ReplayPool):
             field_name: getattr(self, field_name)[indices]
             for field_name in field_names
         }
+
+    def save_latest_experience(self, pickle_path):
+        latest_samples = self.last_n_batch(self._samples_since_save)
+
+        with gzip.open(pickle_path, 'wb') as f:
+            pickle.dump(latest_samples, f)
+
+        self._samples_since_save = 0
+
+    def load_experience(self, experience_path):
+        with gzip.open(experience_path, 'rb') as f:
+            latest_samples = pickle.load(f)
+
+        key = list(latest_samples.keys())[0]
+        num_samples = latest_samples[key].shape[0]
+        for field_name, data in latest_samples.items():
+            assert data.shape[0] == num_samples, data.shape
+
+        self.add_samples(num_samples, **latest_samples)
+        self._samples_since_save = 0
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/tests/softlearning/examples/development/main_test.py
+++ b/tests/softlearning/examples/development/main_test.py
@@ -266,7 +266,7 @@ class TestExperimentRunner(tf.test.TestCase):
 
         config = CONFIG.copy()
 
-        config['run_params']['save_replay_pool'] = True
+        config['run_params']['checkpoint_replay_pool'] = True
         experiment_runner = ExperimentRunner(config=config)
 
         session = experiment_runner._session

--- a/tests/softlearning/examples/development/main_test.py
+++ b/tests/softlearning/examples/development/main_test.py
@@ -84,7 +84,9 @@ class TestExperimentRunner(tf.test.TestCase):
         tf.keras.backend.clear_session()
         self.assertFalse(tf.trainable_variables())
 
-        experiment_runner = ExperimentRunner(config=CONFIG)
+        config = CONFIG.copy()
+
+        experiment_runner = ExperimentRunner(config=config)
 
         session = experiment_runner._session
         experiment_runner._build()
@@ -167,7 +169,7 @@ class TestExperimentRunner(tf.test.TestCase):
         tf.keras.backend.clear_session()
         self.assertFalse(tf.trainable_variables())
 
-        experiment_runner_2 = ExperimentRunner(config=CONFIG)
+        experiment_runner_2 = ExperimentRunner(config=config)
         session = experiment_runner_2._session
         self.assertFalse(experiment_runner_2._built)
 
@@ -262,7 +264,10 @@ class TestExperimentRunner(tf.test.TestCase):
         tf.keras.backend.clear_session()
         self.assertFalse(tf.trainable_variables())
 
-        experiment_runner = ExperimentRunner(config=CONFIG)
+        config = CONFIG.copy()
+
+        config['run_params']['save_replay_pool'] = True
+        experiment_runner = ExperimentRunner(config=config)
 
         session = experiment_runner._session
         experiment_runner._build()
@@ -275,8 +280,37 @@ class TestExperimentRunner(tf.test.TestCase):
         self.assertEqual(experiment_runner.replay_pool.size, 0)
         self.assertEqual(session.run(experiment_runner.algorithm._alpha), 1.0)
 
-        for i in range(10):
-            experiment_runner.train()
+        checkpoints = []
+        while (experiment_runner.replay_pool.size
+               < experiment_runner.replay_pool._max_size):
+            for i in range(10):
+                experiment_runner.train()
+            checkpoints.append(experiment_runner.save())
+
+        tf.reset_default_graph()
+        tf.keras.backend.clear_session()
+        self.assertFalse(tf.trainable_variables())
+
+        experiment_runner_2 = ExperimentRunner(config=config)
+        session = experiment_runner_2._session
+        self.assertFalse(experiment_runner_2._built)
+
+        experiment_runner_2.restore(checkpoints[-1])
+
+        replay_pool_1 = experiment_runner.replay_pool
+        replay_pool_2 = experiment_runner_2.replay_pool
+
+        self.assertEqual(replay_pool_1._max_size, replay_pool_2._max_size)
+        self.assertEqual(replay_pool_1.size, replay_pool_2.size)
+        self.assertEqual(replay_pool_2._max_size, replay_pool_2.size)
+        self.assertEqual(
+            set(replay_pool_1.fields.keys()),
+            set(replay_pool_2.fields.keys()))
+
+        for field_name, field_attrs in replay_pool_1.fields.items():
+            np.testing.assert_array_equal(
+                getattr(replay_pool_1, field_name),
+                getattr(replay_pool_2, field_name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Changes target Qs to be initialized with hard update (see #18).
* Adds new `checkpoint_replay_pool` arguments to allow replay pool to *not* be saved in the checkpoints.
* Changes the way replay pool is saved, now saving only the latest experiences instead of the full pool on every checkpoint (see #1).
* Tweaks for `sync_gs.py` script. It now properly uses the `sync_path` argument.

Closes #18 #1 