### PR TITLE
Feature/trajectory replay pool

### DIFF
--- a/examples/development/variants.py
+++ b/examples/development/variants.py
@@ -218,7 +218,16 @@ def get_variant_spec_base(universe, domain, task, policy, algorithm):
         'replay_pool_params': {
             'type': 'SimpleReplayPool',
             'kwargs': {
-                'max_size': 1e6,
+                'max_size': tune.sample_from(lambda spec: (
+                    {
+                        'SimpleReplayPool': int(1e6),
+                        'TrajectoryReplayPool': int(1e4),
+                    }.get(
+                        spec.get('config', spec)
+                        ['replay_pool_params']
+                        ['type'],
+                        int(1e6))
+                )),
             }
         },
         'sampler_params': {

--- a/softlearning/misc/utils.py
+++ b/softlearning/misc/utils.py
@@ -99,12 +99,6 @@ def _save_video(paths, filename):
     writer.release()
 
 
-def _softmax(x):
-    max_x = np.max(x)
-    exp_x = np.exp(x - max_x)
-    return exp_x / np.sum(exp_x)
-
-
 def deep_update(d, *us):
     d = d.copy()
 

--- a/softlearning/replay_pools/__init__.py
+++ b/softlearning/replay_pools/__init__.py
@@ -1,3 +1,4 @@
 from .simple_replay_pool import SimpleReplayPool
 from .extra_policy_info_replay_pool import ExtraPolicyInfoReplayPool
 from .union_pool import UnionPool
+from .trajectory_replay_pool import TrajectoryReplayPool

--- a/softlearning/replay_pools/trajectory_replay_pool.py
+++ b/softlearning/replay_pools/trajectory_replay_pool.py
@@ -1,0 +1,166 @@
+from collections import deque
+import gzip
+import pickle
+from itertools import islice
+
+import numpy as np
+
+from softlearning.utils.numpy import softmax
+from .replay_pool import ReplayPool
+
+
+def random_int_with_variable_range(mins, maxs):
+    result = np.floor(np.random.uniform(mins, maxs)).astype(int)
+    return result
+
+
+class TrajectoryReplayPool(ReplayPool):
+    def __init__(self,
+                 observation_space,
+                 action_space,
+                 max_size):
+        super(TrajectoryReplayPool, self).__init__()
+
+        max_size = int(max_size)
+        self._max_size = max_size
+
+        self._trajectories = deque(maxlen=max_size)
+        self._trajectory_lengths = deque(maxlen=max_size)
+        self._num_samples = 0
+        self._trajectories_since_save = 0
+
+    @property
+    def num_trajectories(self):
+        return len(self._trajectories)
+
+    @property
+    def size(self):
+        return sum(self._trajectory_lengths)
+
+    @property
+    def num_samples(self):
+        return self._num_samples
+
+    def add_paths(self, trajectories):
+        self._trajectories += trajectories
+        self._trajectory_lengths += [
+            trajectory[next(iter(trajectory.keys()))].shape[0]
+            for trajectory in trajectories
+        ]
+        self._trajectories_since_save += len(trajectories)
+
+    def add_path(self, trajectory):
+        self.add_paths([trajectory])
+
+    def add_sample(self, sample):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} only supports adding full paths at"
+            " once.")
+
+    def add_samples(self, samples):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} only supports adding full paths at"
+            " once.")
+
+    def batch_by_indices(self,
+                         episode_indices,
+                         step_indices,
+                         field_name_filter=None):
+        assert len(episode_indices) == len(step_indices)
+
+        batch_size = len(episode_indices)
+        trajectories = [self._trajectories[i] for i in episode_indices]
+
+        batch = {
+            field_name: np.empty(
+                (batch_size, *values.shape[1:]), dtype=values.dtype)
+            for field_name, values in trajectories[0].items()
+        }
+
+        for i, episode in enumerate(trajectories):
+            for field_name, episode_values in episode.items():
+                batch[field_name][i] = episode_values[step_indices[i]]
+
+        return batch
+
+    def random_batch(self, batch_size, *args, **kwargs):
+        num_trajectories = len(self._trajectories)
+        if num_trajectories < 1:
+            return {}
+
+        trajectory_lengths = np.array(self._trajectory_lengths)
+        trajectory_weights = trajectory_lengths / np.sum(trajectory_lengths)
+        trajectory_probabilities = softmax(trajectory_weights)
+
+        trajectory_indices = np.random.choice(
+            np.arange(num_trajectories),
+            size=batch_size,
+            replace=True,
+            p=trajectory_probabilities)
+        first_key = next(iter(
+            self._trajectories[trajectory_indices[0]].keys()))
+        trajectory_lengths = np.array([
+            self._trajectories[trajectory_index][first_key].shape[0]
+            for trajectory_index in trajectory_indices
+        ])
+
+        step_indices = random_int_with_variable_range(
+            np.zeros_like(trajectory_lengths, dtype=np.int64),
+            trajectory_lengths)
+
+        batch = self.batch_by_indices(trajectory_indices, step_indices)
+
+        return batch
+
+    def last_n_batch(self, last_n, field_name_filter=None, **kwargs):
+        num_trajectories = len(self._trajectories)
+        if num_trajectories < 1:
+            return {}
+
+        trajectory_indices = []
+        step_indices = []
+
+        trajectory_lengths = 0
+        for trajectory_index in range(num_trajectories-1, -1, -1):
+            trajectory = self._trajectories[trajectory_index]
+            trajectory_length = trajectory[list(trajectory.keys())[0]].shape[0]
+
+            steps_from_this_episode = min(trajectory_length, last_n - trajectory_lengths)
+            step_indices += list(range(
+                trajectory_length-1,
+                trajectory_length - steps_from_this_episode - 1,
+                -1))
+            trajectory_indices += [trajectory_index] * steps_from_this_episode
+
+            trajectory_lengths += trajectory_length
+
+            if trajectory_lengths >= last_n:
+                break
+
+        trajectory_indices = trajectory_indices[::-1]
+        step_indices = step_indices[::-1]
+
+        batch = self.batch_by_indices(trajectory_indices, step_indices)
+
+        return batch
+
+    def save_latest_experience(self, pickle_path):
+        # deque doesn't support direct slicing, thus need to use islice
+        num_trajectories = self.num_trajectories
+        start_index = max(num_trajectories - self._trajectories_since_save, 0)
+        end_index = num_trajectories
+
+        latest_trajectories = tuple(islice(
+            self._trajectories, start_index, end_index))
+
+        with gzip.open(pickle_path, 'wb') as f:
+            pickle.dump(latest_trajectories, f)
+
+        self._trajectories_since_save = 0
+
+    def load_experience(self, experience_path):
+        with gzip.open(experience_path, 'rb') as f:
+            latest_trajectories = pickle.load(f)
+
+        self.add_paths(latest_trajectories)
+        self._trajectories_since_save = 0

--- a/softlearning/replay_pools/utils.py
+++ b/softlearning/replay_pools/utils.py
@@ -3,11 +3,13 @@ from copy import deepcopy
 from . import (
     simple_replay_pool,
     extra_policy_info_replay_pool,
-    union_pool)
+    union_pool,
+    trajectory_replay_pool)
 
 
 POOL_CLASSES = {
     'SimpleReplayPool': simple_replay_pool.SimpleReplayPool,
+    'TrajectoryReplayPool': trajectory_replay_pool.TrajectoryReplayPool,
     'ExtraPolicyInfoReplayPool': (
         extra_policy_info_replay_pool.ExtraPolicyInfoReplayPool),
     'UnionPool': union_pool.UnionPool,

--- a/softlearning/utils/numpy.py
+++ b/softlearning/utils/numpy.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+
+def softmax(x):
+    max_x = np.max(x)
+    exp_x = np.exp(x - max_x)
+    return exp_x / np.sum(exp_x)

--- a/tests/softlearning/replay_pools/trajectory_replay_pool_test.py
+++ b/tests/softlearning/replay_pools/trajectory_replay_pool_test.py
@@ -1,0 +1,389 @@
+import pickle
+import unittest
+import numpy as np
+
+from softlearning.replay_pools.trajectory_replay_pool import (
+    TrajectoryReplayPool)
+
+
+def create_pool(max_size=100):
+    return TrajectoryReplayPool(
+        observation_space=None,
+        action_space=None,
+        max_size=max_size,
+    )
+
+
+def verify_pools_match(pool1, pool2):
+    for key in pool2.__dict__:
+        if key == '_trajectories':
+            pool1_trajectories = pool1.__dict__[key]
+            pool2_trajectories = pool2.__dict__[key]
+            for pool1_trajectory, pool2_trajectory in (
+                    zip(pool1_trajectories, pool2_trajectories)):
+                assert pool1_trajectory.keys() == pool2_trajectory.keys()
+                for field_name in pool1_trajectory.keys():
+                    np.testing.assert_array_equal(
+                        pool1_trajectory[field_name],
+                        pool2_trajectory[field_name],
+                        f"key '{key}', field_name '{field_name}' doesn't match"
+                    )
+        else:
+            np.testing.assert_array_equal(
+                pool1.__dict__[key],
+                pool2.__dict__[key],
+                f"key '{key}' doesn't match")
+
+
+class TrajectoryReplayPoolTest(unittest.TestCase):
+    def setUp(self):
+        self.pool = create_pool(10)
+
+    def test_save_load_latest_experience(self):
+        self.assertEqual(self.pool._trajectories_since_save, 0)
+
+        num_trajectories_per_save = self.pool._max_size // 2
+        trajectory_length = 10
+        trajectories = [
+            {
+                'field1': np.arange(trajectory_length)[:, None],
+                'field2': -np.arange(trajectory_length)[:, None] * 2,
+            }
+            for _ in range(num_trajectories_per_save)
+        ]
+
+        self.pool.add_paths(trajectories)
+
+        self.assertEqual(self.pool.num_trajectories, num_trajectories_per_save)
+        self.assertEqual(self.pool.size,
+                         num_trajectories_per_save * trajectory_length)
+        self.assertEqual(self.pool._trajectories_since_save,
+                         num_trajectories_per_save)
+
+        self.pool.save_latest_experience('./tmp/pool_1.pkl')
+
+        self.assertEqual(self.pool._trajectories_since_save, 0)
+
+        self.pool.add_paths(trajectories)
+
+        self.assertEqual(self.pool.size,
+                         self.pool._max_size * trajectory_length)
+        self.assertEqual(self.pool._trajectories_since_save,
+                         num_trajectories_per_save)
+
+        self.pool.save_latest_experience('./tmp/pool_2.pkl')
+
+        self.pool.add_paths(trajectories)
+
+        self.assertEqual(self.pool.size,
+                         self.pool._max_size * trajectory_length)
+        self.assertEqual(self.pool._trajectories_since_save,
+                         num_trajectories_per_save)
+
+        self.pool.save_latest_experience('./tmp/pool_3.pkl')
+
+        pool = create_pool(self.pool._max_size)
+
+        self.assertEqual(pool.size, 0)
+        pool.load_experience('./tmp/pool_1.pkl')
+        self.assertEqual(pool.num_trajectories, self.pool._max_size // 2)
+        self.assertEqual(pool.size,
+                         (self.pool._max_size // 2) * trajectory_length)
+        pool.load_experience('./tmp/pool_2.pkl')
+        self.assertEqual(pool.num_trajectories, self.pool._max_size)
+        self.assertEqual(pool.size,
+                         (self.pool._max_size) * trajectory_length)
+        self.assertEqual(pool.size, self.pool.size)
+        pool.load_experience('./tmp/pool_3.pkl')
+        self.assertEqual(pool.size, self.pool.size)
+        self.assertEqual(pool.size,
+                         (self.pool._max_size) * trajectory_length)
+
+        for trajectory1, trajectory2 in zip(
+                pool._trajectories, self.pool._trajectories):
+            self.assertEqual(trajectory1.keys(), trajectory2.keys())
+            for key in trajectory1:
+                np.testing.assert_array_equal(trajectory1[key], trajectory2[key])
+
+    def test_save_load_latest_experience_empty_pool(self):
+        self.assertEqual(self.pool._trajectories_since_save, 0)
+        self.pool.save_latest_experience('./tmp/pool_1.pkl')
+        pool = create_pool(self.pool._max_size)
+        pool.load_experience('./tmp/pool_1.pkl')
+        self.assertEqual(pool.size, 0)
+
+    def test_save_latest_experience_with_overflown_pool(self):
+        self.assertEqual(self.pool._trajectories_since_save, 0)
+
+        num_trajectories = self.pool._max_size + 2
+        trajectory_length = 10
+        trajectories = [
+            {
+                'field1': np.arange(trajectory_length)[:, None],
+                'field2': -np.arange(trajectory_length)[:, None] * 2,
+            }
+            for _ in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(trajectories)
+
+        self.assertEqual(self.pool.num_trajectories, self.pool._max_size)
+        self.assertEqual(self.pool._trajectories_since_save,
+                         self.pool._max_size + 2)
+        self.pool.save_latest_experience('./tmp/pool_1.pkl')
+        pool = create_pool(self.pool._max_size)
+        self.assertEqual(pool.size, 0)
+
+        import gzip
+        with gzip.open('./tmp/pool_1.pkl', 'rb') as f:
+            latest_trajectories = pickle.load(f)
+            self.assertEqual(len(latest_trajectories), self.pool._max_size)
+
+        pool.load_experience('./tmp/pool_1.pkl')
+        self.assertEqual(pool.size,
+                         self.pool._max_size * trajectory_length)
+
+        for trajectory1, trajectory2 in zip(
+                trajectories, self.pool._trajectories):
+            self.assertEqual(trajectory1.keys(), trajectory2.keys())
+            for field_name in trajectory1:
+                np.testing.assert_array_equal(
+                    trajectory1[field_name], trajectory2[field_name])
+
+    def test_serialize_deserialize_full(self):
+        # Fill fields with random data
+        num_trajectories = self.pool._max_size + 2
+        trajectory_length = 10
+        trajectories = [
+            {
+                'field1': np.arange(trajectory_length)[:, None],
+                'field2': -np.arange(trajectory_length)[:, None] * 2,
+            }
+            for _ in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(trajectories)
+
+        self.assertEqual(self.pool.num_trajectories, self.pool._max_size)
+        self.assertEqual(self.pool.size,
+                         trajectory_length * self.pool._max_size)
+
+        serialized = pickle.dumps(self.pool)
+        deserialized = pickle.loads(serialized)
+
+        verify_pools_match(self.pool, deserialized)
+        self.assertNotEqual(id(self.pool), id(deserialized))
+        self.assertEqual(deserialized.num_trajectories, self.pool._max_size)
+        self.assertEqual(deserialized.size,
+                         trajectory_length * self.pool._max_size)
+
+    def test_serialize_deserialize_not_full(self):
+        # Fill fields with random data
+        num_trajectories = self.pool._max_size - 2
+        trajectory_length = 10
+        trajectories = [
+            {
+                'field1': np.arange(trajectory_length)[:, None],
+                'field2': -np.arange(trajectory_length)[:, None] * 2,
+            }
+            for _ in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(trajectories)
+        self.assertEqual(self.pool.num_trajectories, num_trajectories)
+        self.assertEqual(self.pool.size,
+                         num_trajectories * trajectory_length)
+
+        serialized = pickle.dumps(self.pool)
+        deserialized = pickle.loads(serialized)
+
+        verify_pools_match(self.pool, deserialized)
+        self.assertNotEqual(id(self.pool), id(deserialized))
+        self.assertEqual(deserialized.num_trajectories, num_trajectories)
+        self.assertEqual(deserialized.size,
+                         num_trajectories * trajectory_length)
+
+    def test_serialize_deserialize_empty(self):
+        # Fill fields with random data
+
+        self.assertEqual(self.pool.num_trajectories, 0)
+        self.assertEqual(self.pool.size, 0)
+
+        serialized = pickle.dumps(self.pool)
+        deserialized = pickle.loads(serialized)
+
+        verify_pools_match(self.pool, deserialized)
+        self.assertNotEqual(id(self.pool), id(deserialized))
+        self.assertEqual(deserialized.num_trajectories, 0)
+        self.assertEqual(deserialized.size, 0)
+
+    def test_add_path(self):
+        for value in range(self.pool._max_size):
+            path = {
+                'field1': np.array([value]),
+                'field2': np.array([-value*2]),
+            }
+            self.pool.add_path(path)
+
+        self.assertEqual(len(self.pool._trajectories), self.pool._max_size)
+
+        for i, trajectory in enumerate(self.pool._trajectories):
+            np.testing.assert_array_equal(trajectory['field1'], [i])
+            np.testing.assert_array_equal(trajectory['field2'], [-i * 2])
+
+    def test_add_paths(self):
+        num_trajectories = 4
+        path_length = 10
+        paths = [
+            {
+                'field1': np.arange(path_length)[:, None],
+                'field2': -np.arange(path_length)[:, None] * 2,
+            }
+            for _ in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(paths)
+
+        self.assertEqual(self.pool.num_trajectories, num_trajectories)
+        self.assertEqual(self.pool.size, num_trajectories * path_length)
+
+        for trajectory in self.pool._trajectories:
+            np.testing.assert_array_equal(
+                trajectory['field1'],
+                np.arange(path_length)[:, None])
+            np.testing.assert_array_equal(
+                trajectory['field2'],
+                -np.arange(path_length)[:, None] * 2)
+
+    def test_random_batch(self):
+        empty_pool_batch = self.pool.random_batch(4)
+        self.assertFalse(empty_pool_batch)
+
+        num_trajectories = 4
+        trajectory_length = 10
+        trajectories = [
+            {
+                'field1': np.arange(trajectory_length)[:, None],
+                'field2': -np.arange(trajectory_length)[:, None] * 2,
+            }
+            for _ in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(trajectories)
+
+        full_pool_batch = self.pool.random_batch(4)
+
+        for key, values in full_pool_batch.items():
+            self.assertEqual(values.shape, (4, 1))
+
+        self.assertTrue(np.all(full_pool_batch['field1'] >= 0))
+
+        self.assertTrue(np.all(full_pool_batch['field2'] % 2 == 0))
+        self.assertTrue(np.all(full_pool_batch['field2'] <= 0))
+
+    def test_random_batch_with_variable_length_trajectories(self):
+        batch_size = 256
+        num_trajectories = 20
+        trajectories = [
+            {
+                'field1': np.arange(np.random.randint(50, 1000))[:, None],
+            }
+            for _ in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(trajectories)
+
+        batch = self.pool.random_batch(batch_size)
+        for key, values in batch.items():
+            self.assertEqual(values.shape, (batch_size, 1))
+
+    def test_last_n_batch(self):
+        empty_pool_batch = self.pool.last_n_batch(4)
+        self.assertFalse(empty_pool_batch)
+
+        num_trajectories = 4
+        trajectory_length = 10
+        trajectories = [
+            {
+                'field1': i * np.arange(trajectory_length)[:, None],
+                'field2': -i * np.arange(trajectory_length)[:, None] * 2,
+            }
+            for i in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(trajectories)
+        full_pool_batch = self.pool.last_n_batch(int(trajectory_length * 2.5))
+
+        for key, values in full_pool_batch.items():
+            expected = np.concatenate((
+                trajectories[-3][key][trajectory_length // 2:],
+                trajectories[-2][key],
+                trajectories[-1][key]
+            ))
+            np.testing.assert_array_equal(values, expected)
+            self.assertEqual(values.shape, (2.5 * trajectory_length, 1))
+
+        self.pool.add_paths(trajectories)
+        full_pool_batch = self.pool.last_n_batch(int(trajectory_length * 2))
+
+        for key, values in full_pool_batch.items():
+            expected = np.concatenate((
+                trajectories[-2][key],
+                trajectories[-1][key]
+            ))
+            np.testing.assert_array_equal(values, expected)
+            self.assertEqual(values.shape, (2 * trajectory_length, 1))
+
+    def test_last_n_batch_with_overflown_pool(self):
+        num_trajectories = self.pool._max_size + 2
+        trajectory_length = 10
+        trajectories = [
+            {
+                'field1': i * np.arange(trajectory_length)[:, None],
+                'field2': -i * np.arange(trajectory_length)[:, None] * 2,
+            }
+            for i in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(trajectories)
+        full_pool_batch = self.pool.last_n_batch(int(trajectory_length * 2.5))
+
+        for key, values in full_pool_batch.items():
+            expected = np.concatenate((
+                trajectories[-3][key][trajectory_length // 2:],
+                trajectories[-2][key],
+                trajectories[-1][key]
+            ))
+            np.testing.assert_array_equal(values, expected)
+            self.assertEqual(values.shape, (2.5 * trajectory_length, 1))
+
+    def test_batch_by_indices(self):
+        with self.assertRaises(TypeError):
+            self.pool.batch_by_indices(np.array([-1, 2, 4]))
+
+        num_trajectories = 4
+        trajectory_length = 10
+        trajectories = [
+            {
+                'field1': np.arange(trajectory_length)[:, None],
+                'field2': -np.arange(trajectory_length)[:, None] * 2,
+            }
+            for _ in range(num_trajectories)
+        ]
+
+        self.pool.add_paths(trajectories)
+
+        batch = self.pool.batch_by_indices(
+            np.repeat(np.arange(num_trajectories), trajectory_length),
+            np.tile(np.flip(np.arange(trajectory_length)), num_trajectories))
+
+        for field_name, values in batch.items():
+            field_expected = np.concatenate([
+                np.flip(trajectory[field_name]) for trajectory in trajectories])
+            np.testing.assert_array_equal(
+                batch[field_name],
+                field_expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements `TrajectoryReplayPool`, which a bit slower than our default `SimpleReplayPool` but keeps track of trajectories in the pool, and thus allows it to be used for example for HER-like sampling.