### PR TITLE
Fix a naming error that prevents running the ImageReach-v0 task

### DIFF
--- a/softlearning/environments/gym/__init__.py
+++ b/softlearning/environments/gym/__init__.py
@@ -55,17 +55,17 @@ MUJOCO_ENVIRONMENT_SPECS = (
     {
         'id': 'Pusher2d-ImageDefault-v0',
         'entry_point': (f'{MUJOCO_ENVIRONMENTS_PATH}'
-                        '.image_pusher:ImagePusherEnv'),
+                        '.image_pusher_2d:ImagePusher2dEnv'),
     },
     {
         'id': 'Pusher2d-ImageReach-v0',
         'entry_point': (f'{MUJOCO_ENVIRONMENTS_PATH}'
-                        '.image_pusher:ImageForkReacherEnv'),
+                        '.image_pusher_2d:ImageForkReacher2dEnv'),
     },
     {
         'id': 'Pusher2d-BlindReach-v0',
         'entry_point': (f'{MUJOCO_ENVIRONMENTS_PATH}'
-                        '.image_pusher:BlindForkReacherEnv'),
+                        '.image_pusher_2d:BlindForkReacher2dEnv'),
     },
 )
 

--- a/softlearning/environments/gym/mujoco/image_pusher_2d.py
+++ b/softlearning/environments/gym/mujoco/image_pusher_2d.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from softlearning.environments.helpers import random_point_in_circle
-from .pusher_2d_env import Pusher2dEnv
+from .pusher_2d import Pusher2dEnv
 
 
 class ImagePusher2dEnv(Pusher2dEnv):


### PR DESCRIPTION
Before this change, running the domain Pusher2d for the task ImageReach-v0 returns an error. This change modifies the module names for the ImageReach-v0 task to point to files that actually exist in this repo.