### PR TITLE
Fix Point2DEnv-Default-v0 entrypoint

### DIFF
--- a/examples/development/variants.py
+++ b/examples/development/variants.py
@@ -177,10 +177,10 @@ ENV_PARAMS = {
     },
     'Point2DEnv': {
         'Default-v0': {
-            'observation_keys': ('observation', ),
+            'observation_keys': ('observation', 'desired_goal'),
         },
         'Wall-v0': {
-            'observation_keys': ('observation', ),
+            'observation_keys': ('observation', 'desired_goal'),
         },
     }
 }

--- a/examples/instrument.py
+++ b/examples/instrument.py
@@ -162,7 +162,7 @@ def confirm_yes_no(prompt):
         elif choice in no:
             exit(0)
         else:
-            print("Please respond with 'yes' or 'no'")
+            print("Please respond with 'yes' or 'no'.\n(yes/no)")
         choice = input().lower()
 
 
@@ -230,15 +230,11 @@ def run_example_local(example_module_name,
 def run_example_debug(example_module_name, example_argv):
     """The debug mode limits tune trial runs to enable use of debugger.
 
-    TODO(hartikainen): The debug mode should allow easy switch between
-    parallelized andnon-parallelized runs such that the debugger can be
-    reasonably used when running the code. This could be implemented for
-    example by requiring a custom resource (e.g. 'debug-resource') that
-    limits the number of parallel runs to one. For this to work, tune needs to
-    merge the support for custom resources:
-    https://github.com/ray-project/ray/pull/2979. Alternatively, this could be
-    implemented using the 'local_mode' argument for ray.init(), once tune
-    supports it.
+    The debug mode should allow easy switch between parallelized and
+    non-parallelized runs such that the debugger can be reasonably used when
+    running the code. TODO(hartikainen): this should be implemented using the
+    'ray.init(local_mode=True)', once tune supports it
+    (https://github.com/ray-project/ray/issues/2796).
     """
 
     example_argv = (

--- a/softlearning/environments/gym/__init__.py
+++ b/softlearning/environments/gym/__init__.py
@@ -80,7 +80,7 @@ GENERAL_ENVIRONMENT_SPECS = (
 MULTIWORLD_ENVIRONMENT_SPECS = (
     {
         'id': 'Point2DEnv-Default-v0',
-        'entry_point': 'multiworld.envs.pygame.point2d:Point2DWallEnv'
+        'entry_point': 'multiworld.envs.pygame.point2d:Point2DEnv'
     },
     {
         'id': 'Point2DEnv-Wall-v0',


### PR DESCRIPTION
`Point2DEnv-Default-v0` previously incorrectly pointed to the environment with walls. This changes the entry point to `Point2DEnv`. Also, adds the `desired_goal` to the point2d environments' default variants.
