### PR TITLE
Resurrect SquashBijector due to numerical instability in tfb.Tanh

### DIFF
--- a/softlearning/distributions/squash_bijector.py
+++ b/softlearning/distributions/squash_bijector.py
@@ -1,0 +1,20 @@
+import numpy as np
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+
+class SquashBijector(tfp.bijectors.Bijector):
+    def __init__(self, validate_args=False, name="tanh"):
+        super(SquashBijector, self).__init__(
+            forward_min_event_ndims=0,
+            validate_args=validate_args,
+            name=name)
+
+    def _forward(self, x):
+        return tf.nn.tanh(x)
+
+    def _inverse(self, y):
+        return tf.atanh(y)
+
+    def _forward_log_det_jacobian(self, x):
+        return 2. * (np.log(2.) - x - tf.nn.softplus(-2. * x))

--- a/softlearning/policies/gaussian_policy.py
+++ b/softlearning/policies/gaussian_policy.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
+from softlearning.distributions.squash_bijector import SquashBijector
 from softlearning.models.feedforward import feedforward_model
 
 from .base_policy import LatentSpacePolicy
@@ -92,7 +93,7 @@ class GaussianPolicy(LatentSpacePolicy):
         )((shift, log_scale_diag, self.latents_input))
 
         squash_bijector = (
-            tfp.bijectors.Tanh()
+            SquashBijector()
             if self._squash
             else tfp.bijectors.Identity())
 

--- a/tests/softlearning/policies/squash_bijector_test.py
+++ b/tests/softlearning/policies/squash_bijector_test.py
@@ -1,0 +1,55 @@
+import unittest
+import tensorflow as tf
+import tensorflow_probability as tfp
+import numpy as np
+
+from softlearning.distributions.squash_bijector import SquashBijector
+tf.enable_eager_execution()
+
+
+class TestSquashBijector(unittest.TestCase):
+    def test_matches_tanh_bijector_single(self):
+        squash = SquashBijector()
+        tanh = tfp.bijectors.Tanh()
+        data = np.linspace(-5, 5, 100).astype(np.float32)
+
+        squash_forward = squash.forward(data)
+        tanh_forward = tanh.forward(data)
+
+        np.testing.assert_equal(
+            squash_forward.numpy(), tanh_forward.numpy())
+
+        squash_ildj = squash.inverse_log_det_jacobian(
+            squash_forward, event_ndims=0)
+        tanh_ildj = tanh.inverse_log_det_jacobian(
+            tanh_forward, event_ndims=0)
+
+        tanh_isfinite_mask = np.where(np.isfinite(tanh_ildj))
+
+        np.testing.assert_allclose(
+            tanh_ildj.numpy()[tanh_isfinite_mask],
+            squash_ildj.numpy()[tanh_isfinite_mask],
+            rtol=1e-3)
+
+    def test_matches_tanh_bijector_double(self):
+        squash = SquashBijector()
+        tanh = tfp.bijectors.Tanh()
+        data = np.linspace(-10, 10, 100).astype(np.float64)
+
+        squash_forward = squash.forward(data)
+        tanh_forward = tanh.forward(data)
+
+        np.testing.assert_equal(
+            squash_forward.numpy(), tanh_forward.numpy())
+
+        squash_ildj = squash.inverse_log_det_jacobian(
+            squash_forward, event_ndims=0)
+        tanh_ildj = tanh.inverse_log_det_jacobian(
+            tanh_forward, event_ndims=0)
+
+        np.testing.assert_allclose(
+            squash_ildj.numpy(), tanh_ildj.numpy())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fixes the instability that was introduced in #51. The `tfp.bijectors.Tanh` still caused some issues which is why we need to revert back to using our custom `SquashBijector`. Consider getting rid of this again when https://github.com/tensorflow/probability/issues/318 is fixed.