### PR TITLE
Set the seeds for both training and eval environments

### DIFF
--- a/examples/development/main.py
+++ b/examples/development/main.py
@@ -46,6 +46,14 @@ class ExperimentRunner(tune.Trainable):
             get_environment_from_params(environment_params['evaluation'])
             if 'evaluation' in environment_params
             else training_environment)
+        
+        seed = variant['run_params']['seed']
+        
+        training_environment.seed(seed)
+        
+        # Set a different seed for the evaluation env
+        # to ensure the policy is not just memorizing action sequences for seen initial states
+        evaluation_environment.seed(seed + 10)
 
         replay_pool = self.replay_pool = (
             get_replay_pool_from_variant(variant, training_environment))


### PR DESCRIPTION
Pull request for https://github.com/rail-berkeley/softlearning/issues/80