### PR TITLE
Misc tweaks 20190601

### DIFF
--- a/softlearning/algorithms/rl_algorithm.py
+++ b/softlearning/algorithms/rl_algorithm.py
@@ -360,7 +360,8 @@ class RLAlgorithm(Checkpointable):
         """Compute evaluation metrics for the given rollouts."""
 
         episodes_rewards = [episode['rewards'] for episode in episodes]
-        episodes_reward = np.sum(episodes_rewards, axis=1)
+        episodes_reward = [np.sum(episode_rewards)
+                           for episode_rewards in episodes_rewards]
         episodes_length = [episode_rewards.shape[0]
                            for episode_rewards in episodes_rewards]
 

--- a/softlearning/models/convnet.py
+++ b/softlearning/models/convnet.py
@@ -7,12 +7,7 @@ from softlearning.models.normalization import (
     LayerNormalization,
     GroupNormalization,
     InstanceNormalization)
-
-from distutils.version import LooseVersion
-if LooseVersion(tf.__version__) > LooseVersion("2.00"):
-    from tensorflow import nest
-else:
-    from tensorflow.contrib.framework import nest
+from softlearning.utils.tensorflow import nest
 
 
 tfk = tf.keras

--- a/softlearning/models/feedforward.py
+++ b/softlearning/models/feedforward.py
@@ -3,12 +3,7 @@ import tensorflow_probability as tfp
 from tensorflow.python.keras.engine import training_utils
 
 from softlearning.utils.keras import PicklableSequential
-
-from distutils.version import LooseVersion
-if LooseVersion(tf.__version__) > LooseVersion("2.00"):
-    from tensorflow import nest
-else:
-    from tensorflow.contrib.framework import nest
+from softlearning.utils.tensorflow import nest
 
 
 tfk = tf.keras

--- a/softlearning/models/utils.py
+++ b/softlearning/models/utils.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
-from flatten_dict import flatten
+
+from softlearning.utils.tensorflow import nest
 
 
 def get_inputs_for_nested_shapes(input_shapes, name=None):
@@ -23,21 +24,19 @@ def get_inputs_for_nested_shapes(input_shapes, name=None):
 
 
 def flatten_input_structure(inputs):
-    if isinstance(inputs, dict):
-        inputs_flat_dict = flatten(inputs)
-        inputs_flat = [
-            inputs_flat_dict[key]
-            for key in sorted(inputs_flat_dict.keys())
-        ]
-    elif isinstance(inputs, list):
-        inputs_flat = list(inputs)
-    elif isinstance(inputs, tuple):
-        if all (isinstance(x, int) for x in inputs):
-            inputs_flat = [inputs]
-        else:
-            inputs_flat = list(inputs)
-
+    inputs_flat = nest.flatten(inputs)
     return inputs_flat
+
+
+def create_input(name, input_shape):
+    input_ = tf.keras.layers.Input(
+        shape=input_shape,
+        name=name,
+        dtype=(tf.uint8 # Image observation
+               if len(input_shape) == 3 and input_shape[-1] in (1, 3)
+               else tf.float32) # Non-image
+    )
+    return input_
 
 
 def create_inputs(input_shapes):
@@ -48,34 +47,12 @@ def create_inputs(input_shapes):
         inputs shapes.
 
     Returns:
-        inputs_flat: a tuple of `tf.keras.layers.Input`s.
+        inputs: nested structure, of same shape as input_shapes, containing
+        `tf.keras.layers.Input`s.
 
     TODO(hartikainen): Need to figure out a better way for handling the dtypes.
     """
-    if isinstance(input_shapes, dict):
-        inputs_flat_dict = flatten(input_shapes)
-        inputs_flat = [
-            tf.keras.layers.Input(
-                shape=inputs_flat_dict[key],
-                name=key[-1],
-                dtype=(tf.uint8 # Image observation
-                       if len(inputs_flat_dict[key]) == 3
-                       else tf.float32) # Non-image
-            )
-            for key in sorted(inputs_flat_dict.keys())
-        ]
-    elif isinstance(input_shapes, list):
-        inputs_flat = [
-            tf.keras.layers.Input(shape=shape)
-            for shape in input_shapes
-        ]
-    elif isinstance(input_shapes, tuple):
-        if all (isinstance(x, int) for x in input_shapes):
-            inputs_flat = [tf.keras.layers.Input(shape=input_shapes)]
-        else:
-            inputs_flat = [
-                tf.keras.layers.Input(shape=shape)
-                for shape in input_shapes
-            ]
+    inputs = nest.map_structure_with_paths(create_input, input_shapes)
+    inputs_flat = flatten_input_structure(inputs)
 
     return inputs_flat

--- a/softlearning/replay_pools/flexible_replay_pool.py
+++ b/softlearning/replay_pools/flexible_replay_pool.py
@@ -147,8 +147,10 @@ class FlexibleReplayPool(ReplayPool):
 
     def last_n_batch(self, last_n, field_name_filter=None, **kwargs):
         last_n_indices = np.arange(
-            self._pointer - min(self.size, last_n), self._pointer
+            self._pointer - min(self.size, int(last_n)), self._pointer,
+            dtype=int
         ) % self._max_size
+
         return self.batch_by_indices(
             last_n_indices, field_name_filter=field_name_filter, **kwargs)
 

--- a/softlearning/replay_pools/goal_replay_pool.py
+++ b/softlearning/replay_pools/goal_replay_pool.py
@@ -1,18 +1,44 @@
 from gym.spaces import Dict
 
-from .flexible_replay_pool import Field
-from .simple_replay_pool import SimpleReplayPool
+from .flexible_replay_pool import FlexibleReplayPool, Field
 
 
-class GoalReplayPool(SimpleReplayPool):
+class GoalReplayPool(FlexibleReplayPool):
     def __init__(self,
                  environment,
+                 observation_fields=None,
+                 new_observation_fields=None,
                  *args,
+                 extra_fields=None,
                  **kwargs):
+        extra_fields = extra_fields or {}
         observation_space = environment.observation_space
+        action_space = environment.action_space
         assert isinstance(observation_space, Dict), observation_space
 
-        extra_fields = {
+        self._environment = environment
+        self._observation_space = observation_space
+        self._action_space = action_space
+
+        fields = {
+            'observations': {
+                name: Field(
+                    name=name,
+                    dtype=observation_space.dtype,
+                    shape=observation_space.shape)
+                for name, observation_space
+                in observation_space.spaces.items()
+                if name not in environment.goal_key_map.keys()
+            },
+            'next_observations': {
+                name: Field(
+                    name=name,
+                    dtype=observation_space.dtype,
+                    shape=observation_space.shape)
+                for name, observation_space
+                in observation_space.spaces.items()
+                if name not in environment.goal_key_map.keys()
+            },
             'goals': {
                 name: Field(
                     name=name,
@@ -20,9 +46,23 @@ class GoalReplayPool(SimpleReplayPool):
                     shape=observation_space.shape)
                 for name, observation_space
                 in observation_space.spaces.items()
-                if name in environment.goal_keys
+                if name in environment.goal_key_map.values()
             },
+            'actions': Field(
+                name='actions',
+                dtype=action_space.dtype,
+                shape=action_space.shape),
+            'rewards': Field(
+                name='rewards',
+                dtype='float32',
+                shape=(1, )),
+            # terminals[i] = a terminal was received at time i
+            'terminals': Field(
+                name='terminals',
+                dtype='bool',
+                shape=(1, )),
+            **extra_fields
         }
 
-        return super(GoalReplayPool, self).__init__(
-            environment, *args, **kwargs, extra_fields=extra_fields)
+        super(GoalReplayPool, self).__init__(
+            *args, fields=fields, **kwargs)

--- a/softlearning/replay_pools/goal_replay_pool.py
+++ b/softlearning/replay_pools/goal_replay_pool.py
@@ -64,5 +64,31 @@ class GoalReplayPool(FlexibleReplayPool):
             **extra_fields
         }
 
-        super(GoalReplayPool, self).__init__(
-            *args, fields=fields, **kwargs)
+        super(GoalReplayPool, self).__init__(*args, fields=fields, **kwargs)
+
+    def add_samples(self, samples, *args, **kwargs):
+        full_observations = samples['observations']
+        observations = type(full_observations)(
+            (key, values)
+            for key, values in full_observations.items()
+            if key not in self._environment.goal_key_map.keys()
+        )
+        next_observations = type(samples['next_observations'])(
+            (key, values)
+            for key, values in samples['next_observations'].items()
+            if key not in self._environment.goal_key_map.keys()
+        )
+        goals = type(full_observations)(
+            (goal_key, full_observations[observation_key])
+            for observation_key, goal_key
+            in self._environment.goal_key_map.items()
+        )
+
+        samples.update({
+            'observations': observations,
+            'next_observations': next_observations,
+            'goals': goals,
+        })
+
+        return super(GoalReplayPool, self).add_samples(
+            samples, *args, **kwargs)

--- a/softlearning/replay_pools/hindsight_experience_replay_pool.py
+++ b/softlearning/replay_pools/hindsight_experience_replay_pool.py
@@ -92,17 +92,37 @@ class ResamplingReplayPool(GoalReplayPool):
         return resample_indices, resample_distances
 
 
+def REPLACE_FULL_OBSERVATION(original_batch,
+                             resampled_batch,
+                             where_resampled):
+    batch_flat = flatten(original_batch)
+    resampled_batch_flat = flatten(original_batch)
+    goal_keys = [
+        key for key in batch_flat.keys()
+        if key[0] == 'goals'
+    ]
+    for key in goal_keys:
+        assert (batch_flat[key][where_resampled].shape
+                == resampled_batch_flat[key].shape)
+        batch_flat[key][where_resampled] = (
+            resampled_batch_flat[key])
+
+    return unflatten(batch_flat)
+
+
 class HindsightExperienceReplayPool(ResamplingReplayPool):
     def __init__(self,
                  *args,
                  her_strategy=None,
-                 reward_function=None,
-                 terminal_function=None,
+                 update_batch_fn=REPLACE_FULL_OBSERVATION,
+                 reward_fn=None,
+                 terminal_fn=None,
                  **kwargs):
         self._her_strategy = her_strategy
-        self._reward_function = reward_function or (
+        self._update_batch_fn = update_batch_fn
+        self._reward_fn = reward_fn or (
             lambda x: x[('rewards', )])
-        self._terminal_function = terminal_function or (
+        self._terminal_fn = terminal_fn or (
             lambda x: x[('terminals', )])
         super(HindsightExperienceReplayPool, self).__init__(*args, **kwargs)
 
@@ -133,35 +153,23 @@ class HindsightExperienceReplayPool(ResamplingReplayPool):
                 episode_last_distances,
                 her_strategy_type)
 
-            resampled_batch_flat = flatten(
-                super(HindsightExperienceReplayPool, self)
-                .batch_by_indices(
-                    indices=resampled_indices,
-                    field_name_filter=None))
-
-            batch_flat = flatten(batch)
-            goal_keys = [
-                key for key in batch_flat.keys()
-                if key[0] == 'goals'
-            ]
-            for key in goal_keys:
-                assert (batch_flat[key][where_resampled].shape
-                        == resampled_batch_flat[key].shape)
-                batch_flat[key][where_resampled] = (
-                    resampled_batch_flat[key])
-
-            if self._reward_function:
-                batch_flat[('rewards', )][where_resampled] = (
-                    self._reward_function(resampled_batch_flat))
-            if self._terminal_function:
-                batch_flat[('terminals', )][where_resampled] = (
-                    self._terminal_function(resampled_batch_flat))
-
-            batch = unflatten(batch_flat)
+            resampled_batch = super(
+                HindsightExperienceReplayPool, self
+            ).batch_by_indices(
+                indices=resampled_indices,
+                field_name_filter=None)
 
             batch['resampled_distances'][where_resampled] = (
                 resampled_distances)
             batch['resampled'][where_resampled] = True
+
+            batch = self._update_batch_fn(
+                batch, resampled_batch, where_resampled)
+
+            if self._reward_fn:
+                self._reward_fn(batch, where_resampled, self._environment)
+            if self._terminal_fn:
+                self._terminal_fn(batch, where_resampled, self._environment)
 
         return batch
 

--- a/softlearning/replay_pools/hindsight_experience_replay_pool.py
+++ b/softlearning/replay_pools/hindsight_experience_replay_pool.py
@@ -70,7 +70,7 @@ class ResamplingReplayPool(GoalReplayPool):
                 where_same_episode
             ] = (
                 resample_indices[where_same_episode]
-                - resample_indices[where_same_episode]
+                - indices[where_same_episode]
             )[..., None]
         else:
             if resampling_strategy == 'final':

--- a/softlearning/utils/tensorflow.py
+++ b/softlearning/utils/tensorflow.py
@@ -1,0 +1,9 @@
+from distutils.version import LooseVersion
+
+import tensorflow as tf
+
+
+if LooseVersion(tf.__version__) > LooseVersion("2.00"):
+    from tensorflow import nest
+else:
+    from tensorflow.contrib.framework import nest


### PR DESCRIPTION
* Update `GoalReplayPool` to have separate observations and goals fields.
* Fix `simulate_policy.py` `render_kwargs` (closes #90).
* Use `tf.nest` for input flattening.
* Update `HindsightExperienceReplayPool` to allow customized batch updated by `update_batch_fn`.
* Force `dtype=int` in `FlexibleReplayPool.last_n_batch` index generation.
* Fix `resampling_strategy == 'random'` indices.