### PR TITLE
Fix no such command error

### DIFF
--- a/scripts/install_mujoco.py
+++ b/scripts/install_mujoco.py
@@ -48,7 +48,7 @@ def install_mujoco(platform, version, mujoco_path):
 
     mujoco_zip_url = f"https://www.roboti.us/download/{mujoco_zip_name}"
 
-    if subprocess.call(["which", "wget"]) == 0:
+    if subprocess.call(["command", "-v", "wget"], shell=True) == 0:
         subprocess.check_call([
             "wget",
             "--progress=bar:force",

--- a/scripts/install_mujoco.py
+++ b/scripts/install_mujoco.py
@@ -57,7 +57,7 @@ def install_mujoco(platform, version, mujoco_path):
             "--directory-prefix",
             mujoco_path,
             mujoco_zip_url])
-    elif subprocess.call(["which", "curl"]) == 0:
+    elif subprocess.call(["command", "-v", "curl"]) == 0:
         subprocess.check_call([
             "curl",
             "--location",

--- a/scripts/install_mujoco.py
+++ b/scripts/install_mujoco.py
@@ -48,7 +48,7 @@ def install_mujoco(platform, version, mujoco_path):
 
     mujoco_zip_url = f"https://www.roboti.us/download/{mujoco_zip_name}"
 
-    if subprocess.call(["which", "-v", "wget"]) == 0:
+    if subprocess.call(["which", "wget"]) == 0:
         subprocess.check_call([
             "wget",
             "--progress=bar:force",
@@ -57,7 +57,7 @@ def install_mujoco(platform, version, mujoco_path):
             "--directory-prefix",
             mujoco_path,
             mujoco_zip_url])
-    elif subprocess.call(["which", "-v", "curl"]) == 0:
+    elif subprocess.call(["which", "curl"]) == 0:
         subprocess.check_call([
             "curl",
             "--location",

--- a/scripts/install_mujoco.py
+++ b/scripts/install_mujoco.py
@@ -48,7 +48,7 @@ def install_mujoco(platform, version, mujoco_path):
 
     mujoco_zip_url = f"https://www.roboti.us/download/{mujoco_zip_name}"
 
-    if subprocess.call(["command", "-v", "wget"]) == 0:
+    if subprocess.call(["which", "-v", "wget"]) == 0:
         subprocess.check_call([
             "wget",
             "--progress=bar:force",
@@ -57,7 +57,7 @@ def install_mujoco(platform, version, mujoco_path):
             "--directory-prefix",
             mujoco_path,
             mujoco_zip_url])
-    elif subprocess.call(["command", "-v", "curl"]) == 0:
+    elif subprocess.call(["which", "-v", "curl"]) == 0:
         subprocess.check_call([
             "curl",
             "--location",

--- a/scripts/install_mujoco.py
+++ b/scripts/install_mujoco.py
@@ -57,7 +57,7 @@ def install_mujoco(platform, version, mujoco_path):
             "--directory-prefix",
             mujoco_path,
             mujoco_zip_url])
-    elif subprocess.call(["command", "-v", "curl"]) == 0:
+    elif subprocess.call(["command", "-v", "curl"], shell=True) == 0:
         subprocess.check_call([
             "curl",
             "--location",


### PR DESCRIPTION
On Ubuntu 'command' is only a bash builtin, and not a real command. Consequently `subprocess.call(["command", "-v", "curl"])` throws an error (see below). I am not sure if `which` works on mac, but the docker image does not work in the current state. Therefore, I think it should be fixed.
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/johannes/anaconda3/lib/python3.7/subprocess.py", line 323, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/home/johannes/anaconda3/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/home/johannes/anaconda3/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'command': 'command'
```