### PR TITLE
Use gcloud as a docker credential helper

### DIFF
--- a/config/ray-autoscaler-gce.yaml
+++ b/config/ray-autoscaler-gce.yaml
@@ -103,7 +103,7 @@ setup_commands:
         pip install -U -e ~/softlearning
 
 initialization_commands:
-  - docker-credential-gcr configure-docker
+  - gcloud auth configure-docker
 
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands: []


### PR DESCRIPTION
`docker-credential-gcr` is not available by default on GCE and causes an error. Using `gcloud auth`, which is available by default, is recommended (https://cloud.google.com/container-registry/docs/advanced-authentication#gcloud-helper).