### PR TITLE
Fix shaping in dm_control to gym space conversion

### DIFF
--- a/softlearning/environments/adapters/dm_control_adapter.py
+++ b/softlearning/environments/adapters/dm_control_adapter.py
@@ -32,9 +32,12 @@ def convert_dm_control_to_gym_space(dm_control_space):
     input types in order to enable recursive calling on each nested item.
     """
     if isinstance(dm_control_space, specs.BoundedArray):
+        shape = dm_control_space.shape
+        low = np.broadcast_to(dm_control_space.minimum, shape)
+        high = np.broadcast_to(dm_control_space.maximum, shape)
         gym_box = spaces.Box(
-            low=dm_control_space.minimum,
-            high=dm_control_space.maximum,
+            low=low,
+            high=high,
             shape=None,
             dtype=dm_control_space.dtype)
         # Note: `gym.Box` doesn't allow both shape and min/max to be defined


### PR DESCRIPTION
Fixes the case where `dm_control` spec has non-matching shape and minimum/maximum. `dm_control` handles these the same way as proposed change in this PR: https://github.com/deepmind/dm_env/blob/bd431e18b6547c76b607bb4685225fb1dfa2da65/dm_env/specs.py#L202-L212